### PR TITLE
Change the response type to 401

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -78,8 +78,8 @@ router.get('/authorize', async function (req, res, next) {
     }
 
     throw new Response(undefined, {
-      status: 403,
-      statusText: 'Forbidden',
+      status: 401,
+      statusText: 'Unauthorized',
       headers: new Headers({
         'X-Shopify-Retry-Invalid-Session-Request': '1',
       }),


### PR DESCRIPTION
The 403 response was set by mistake. The existing templates use a 401.